### PR TITLE
Repetitive packaging

### DIFF
--- a/src/rebar3_erllambda_release.erl
+++ b/src/rebar3_erllambda_release.erl
@@ -93,7 +93,7 @@ generate_start_script( Dir, Command, Script ) ->
             % TODO rework for NO symlinks
             file:delete(BootFilename),
             %% create necessary symlink
-            ok = file:make_symlink(Filename, BootFilename);
+            ok = file:make_symlink( "/var/task/" ++ rebar3_erllambda:list(Command), BootFilename);
         {error, Reason} ->
             throw( {generate_start_script_failed, Reason} )
     end.            


### PR DESCRIPTION
need to handle several consecutive runs.
all just cause of linking.

temporary as #2 should fix it and we should not regenerate bootstap file every time 

@velimir0xff FYI