### PR TITLE
Update bootstrap for less coredumps

### DIFF
--- a/priv/bootstrap
+++ b/priv/bootstrap
@@ -20,4 +20,7 @@ $(mkdir -p "${RUN_DIR}/checkpointfs")
 $(mkdir -p "${RUN_DIR}/tmpfs")
 $(mkdir -p "${RUN_DIR}/ramfs")
 
+# we no need coredumps in Lambda
+export ERL_CRASH_DUMP="/dev/null"
+
 exec $SCRIPT_DIR/bin/{{ release_name }}


### PR DESCRIPTION
one more thing to copy over to public while i remember.

there is no need to write coredumps in AWS Lambda since one cannot extract them 