### PR TITLE
Drop unused variable

### DIFF
--- a/src/rebar3_erllambda_release.erl
+++ b/src/rebar3_erllambda_release.erl
@@ -59,7 +59,7 @@ do( State ) ->
         rebar_api:info("running erllambda release generator", []),
         ErllambdaDir = rebar3_erllambda:erllambda_dir( State ),
         StartScript = start_script( ErllambdaDir ),
-        {Command, _} = HandlerInfo = handler_info( State ),
+        {Command, _} = handler_info( State ),
         TargetDir = rebar3_erllambda:target_dir( State ),
         generate_start_script( TargetDir, Command, StartScript ),
         {ok, State}


### PR DESCRIPTION
2020-04-20 11:40:49 GMT+03:00 - ===> Compiling rebar3_erllambda
2020-04-20 11:40:49 GMT+03:00 - _build/default/plugins/rebar3_erllambda/src/rebar3_erllambda_release.erl:62: Warning: variable 'HandlerInfo' is unused